### PR TITLE
Add default CircleCI file

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -41,6 +41,6 @@ test:
     - php artisan twig:lint
     - node_modules/.bin/grunt rebuild
     - node_modules/.bin/grunt lint
-    - vendor/bin/codecept run -vvv --no-interaction --debug --xml="$CIRCLE_TEST_REPORTS/codeception/ignition.xml"
+    - vendor/bin/codecept run -vvv --no-interaction --debug --xml="$CIRCLE_TEST_REPORTS/codeception/project.xml"
     - vendor/bin/phpspec run -vvv --no-interaction --format="pretty"
-    - vendor/bin/phpspec run -vvv --no-interaction --format="junit" > $CIRCLE_TEST_REPORTS/phpspec/ignition.xml # This one is just for CircleCI
+    - vendor/bin/phpspec run -vvv --no-interaction --format="junit" > $CIRCLE_TEST_REPORTS/phpspec/project.xml # This one is just for CircleCI

--- a/circle.yml
+++ b/circle.yml
@@ -27,7 +27,7 @@ dependencies:
     - composer install --prefer-source --no-interaction
     - node_modules/.bin/bower install
     # - php artisan serve: {background: true}
-    # - phantomjs --webdriver="4444" --ignore-ssl-errors="true": {background: true}
+    # - phantomjs --webdriver="4444" --ignore-ssl-errors="true" --webdriver-loglevel="debug" --debug="true": {background: true}
 
 database:
   post:

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,46 @@
+machine:
+  php:
+    version: 5.5.21
+  ruby:
+    version: 2.1.3
+  environment:
+    APP_ENV: testing
+
+general:
+    artifacts:
+        - "tests/codeception/_output"
+        - "storage/logs"
+
+dependencies:
+  cache_directories:
+    - elasticsearch-1.6.0
+    - node_modules
+    - public/components
+  pre:
+    - pecl install xdebug
+    - echo "memory_limit = 1024M" > ~/.phpenv/versions/5.5.15/etc/conf.d/memory.ini
+    - if [[ ! -e elasticsearch-1.6.0 ]]; then wget https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.6.0.tar.gz && tar -xvf elasticsearch-1.6.0.tar.gz; fi
+    - elasticsearch-1.6.0/bin/elasticsearch: {background: true}
+  override:
+    - bundle install
+    - npm install
+    - composer install --prefer-source --no-interaction
+    - node_modules/.bin/bower install
+    # - php artisan serve: {background: true}
+    # - phantomjs --webdriver="4444" --ignore-ssl-errors="true": {background: true}
+
+database:
+  post:
+    - php artisan migrate --seed -vvv
+    - mysqldump -u ubuntu circle_test > tests/codeception/_data/dump.sql
+
+test:
+  pre:
+    - mkdir -p $CIRCLE_TEST_REPORTS/phpspec
+  override:
+    - php artisan twig:lint
+    - node_modules/.bin/grunt rebuild
+    - node_modules/.bin/grunt lint
+    - vendor/bin/codecept run -vvv --no-interaction --debug --xml="$CIRCLE_TEST_REPORTS/codeception/ignition.xml"
+    - vendor/bin/phpspec run -vvv --no-interaction --format="pretty"
+    - vendor/bin/phpspec run -vvv --no-interaction --format="junit" > $CIRCLE_TEST_REPORTS/phpspec/ignition.xml # This one is just for CircleCI

--- a/circle.yml
+++ b/circle.yml
@@ -18,7 +18,7 @@ dependencies:
     - public/components
     - vendor
   pre:
-    - pecl install xdebug
+    - sed -i 's/^;//' ~/.phpenv/versions/$(phpenv global)/etc/conf.d/xdebug.ini
     - echo "memory_limit = 1024M" > ~/.phpenv/versions/5.5.21/etc/conf.d/memory.ini
     - if [[ ! -e elasticsearch-1.6.0 ]]; then wget https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.6.0.tar.gz && tar -xvf elasticsearch-1.6.0.tar.gz; fi
     - elasticsearch-1.6.0/bin/elasticsearch: {background: true}

--- a/circle.yml
+++ b/circle.yml
@@ -16,6 +16,7 @@ dependencies:
     - elasticsearch-1.6.0
     - node_modules
     - public/components
+    - vendor
   pre:
     - pecl install xdebug
     - echo "memory_limit = 1024M" > ~/.phpenv/versions/5.5.21/etc/conf.d/memory.ini

--- a/circle.yml
+++ b/circle.yml
@@ -14,7 +14,6 @@ general:
 dependencies:
   cache_directories:
     - elasticsearch-1.6.0
-    - node_modules
     - public/components
     - vendor
   pre:

--- a/circle.yml
+++ b/circle.yml
@@ -18,7 +18,7 @@ dependencies:
     - public/components
   pre:
     - pecl install xdebug
-    - echo "memory_limit = 1024M" > ~/.phpenv/versions/5.5.15/etc/conf.d/memory.ini
+    - echo "memory_limit = 1024M" > ~/.phpenv/versions/5.5.21/etc/conf.d/memory.ini
     - if [[ ! -e elasticsearch-1.6.0 ]]; then wget https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.6.0.tar.gz && tar -xvf elasticsearch-1.6.0.tar.gz; fi
     - elasticsearch-1.6.0/bin/elasticsearch: {background: true}
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -7,9 +7,9 @@ machine:
     APP_ENV: testing
 
 general:
-    artifacts:
-        - "tests/codeception/_output"
-        - "storage/logs"
+  artifacts:
+    - "tests/codeception/_output"
+    - "storage/logs"
 
 dependencies:
   cache_directories:

--- a/circle.yml
+++ b/circle.yml
@@ -19,7 +19,7 @@ dependencies:
     - vendor
   pre:
     - sed -i 's/^;//' ~/.phpenv/versions/$(phpenv global)/etc/conf.d/xdebug.ini
-    - echo "memory_limit = 1024M" > ~/.phpenv/versions/5.5.21/etc/conf.d/memory.ini
+    - echo "memory_limit = 1024M" > ~/.phpenv/versions/$(phpenv global)/etc/conf.d/memory.ini
     - if [[ ! -e elasticsearch-1.6.0 ]]; then wget https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.6.0.tar.gz && tar -xvf elasticsearch-1.6.0.tar.gz; fi
     - elasticsearch-1.6.0/bin/elasticsearch: {background: true}
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -18,7 +18,7 @@ dependencies:
     - public/components
     - vendor
   pre:
-    - sed -i 's/^;//' ~/.phpenv/versions/$(phpenv global)/etc/conf.d/xdebug.ini
+    # - sed -i 's/^;//' ~/.phpenv/versions/$(phpenv global)/etc/conf.d/xdebug.ini
     - echo "memory_limit = 1024M" > ~/.phpenv/versions/$(phpenv global)/etc/conf.d/memory.ini
     - if [[ ! -e elasticsearch-1.6.0 ]]; then wget https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.6.0.tar.gz && tar -xvf elasticsearch-1.6.0.tar.gz; fi
     - elasticsearch-1.6.0/bin/elasticsearch: {background: true}


### PR DESCRIPTION
### Added
- Add default CircleCI file

---

I read a whole lot of doc on CircleCI over the week-end so this takes advantage of stuff we don't even currently take advange of nowadays, such as build artefacts, test reports, dependencies caching, etc. Also caches the ES installation so it's faster.

PHPSpec is run twice, once for us and once to generate the junit format as PHPSpec doesn't yet support running in multiple formats all at once like Codeception does.

cc @bramdevries @dieterve @xavierbarbosa 
