### PR TITLE
Vagrant: forward SSH key by default.

### DIFF
--- a/vagrant/base-vagrantfile.rb
+++ b/vagrant/base-vagrantfile.rb
@@ -7,6 +7,9 @@ class Skeletor
 	# Configure A Private Network IP
 	config.vm.network :private_network, ip: settings["ip"]
 
+	# Forward SSH key from local
+	config.ssh.forward_agent = true
+
 	# Configure A Few VirtualBox Settings
 	config.vm.provider "virtualbox" do |vb|
 	  vb.customize ["modifyvm", :id, "--memory", "1024"]

--- a/vagrant/project-vagrantfile.rb
+++ b/vagrant/project-vagrantfile.rb
@@ -8,6 +8,9 @@ class Skeletor
 	# Configure A Private Network IP
 	config.vm.network :private_network, ip: settings["ip"]
 
+	# Forward SSH key from local
+	config.ssh.forward_agent = true
+
 	# Configure A Few VirtualBox Settings
 	config.vm.provider "virtualbox" do |vb|
 	  vb.customize ["modifyvm", :id, "--memory", "2048"]


### PR DESCRIPTION
### Changed
- Vagrant: forward local SSH key by default.
## 

Needed when deploys are happening from the vagrant box, for example.
